### PR TITLE
Code audit: fix lint issues, expand CI, add pyproject.toml

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -30,7 +30,7 @@ jobs:
           pip install pytest pytest-cov ruff
 
       - name: Lint (ruff)
-        run: ruff check budget_manager.py
+        run: ruff check budget_manager.py budget_manager_gui.py tests/
 
       - name: Run tests with coverage
         run: |

--- a/budget_manager.py
+++ b/budget_manager.py
@@ -26,13 +26,12 @@ from __future__ import annotations
 import argparse
 import csv
 import json
-import math
 import sys
 from collections import defaultdict
 from dataclasses import dataclass, field
+from datetime import date as _date
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
-from datetime import date as _date
 
 
 @dataclass
@@ -312,7 +311,10 @@ def _is_valid_ymd(s: str) -> bool:
 
 def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Manage monthly income and expenses and compute percentage breakdowns.")
-    p.add_argument("--input", type=str, help="Path to CSV file to import (type,name,category,amount). If omitted, runs interactive mode.")
+    p.add_argument(
+        "--input", type=str,
+        help="Path to CSV file to import (type,name,category,amount). If omitted, runs interactive mode.",
+    )
     p.add_argument("--month", type=str, help="Month label for the report, e.g., 2025-08.")
     p.add_argument("--json", action="store_true", help="Output JSON instead of a human-readable table.")
     p.add_argument("--save-json", type=str, help="Optional path to save the JSON report.")

--- a/budget_manager_gui.py
+++ b/budget_manager_gui.py
@@ -8,24 +8,24 @@ Run: python budget_manager_gui.py
 """
 from __future__ import annotations
 
+import calendar as _cal
 import csv
+import datetime as _dt
 import json
+import math as _math
 import os
 import tkinter as tk
-from tkinter import ttk, messagebox, filedialog
 from pathlib import Path
-import datetime as _dt
-import calendar as _cal
-import math as _math
+from tkinter import filedialog, messagebox, ttk
+
 from openpyxl import Workbook
-from openpyxl.utils import get_column_letter
-from openpyxl.styles import Alignment, Font, numbers
-from openpyxl.chart import BarChart, Reference, PieChart
-from openpyxl.chart.series import DataPoint
+from openpyxl.chart import BarChart, PieChart, Reference
 from openpyxl.chart.label import DataLabelList
+from openpyxl.chart.series import DataPoint
 from openpyxl.formatting.rule import CellIsRule
+from openpyxl.styles import Alignment, Border, Font, PatternFill, Side, numbers
+from openpyxl.utils import get_column_letter
 from openpyxl.worksheet.table import Table, TableStyleInfo
-from openpyxl.styles import PatternFill, Border, Side
 
 from budget_manager import BudgetMonth, read_csv
 
@@ -555,7 +555,7 @@ class BudgetApp(tk.Tk):
                     self._format_day_display(ds),
                 ])
             data_end_exp = ws_exp.max_row
-            ws_exp.append(["Total", "", f"=SUM(C2:C{data_end_exp})", "", ""]) 
+            ws_exp.append(["Total", "", f"=SUM(C2:C{data_end_exp})", "", ""])
             tot_row_exp = ws_exp.max_row
             ws_exp[f"A{tot_row_exp}"].font = Font(bold=True)
             ws_exp[f"C{tot_row_exp}"].font = Font(bold=True)
@@ -587,7 +587,7 @@ class BudgetApp(tk.Tk):
             ws_rep.append(["Total Income", float(self.bm.total_income())])
             ws_rep.append(["Total Expenses", float(self.bm.total_expenses())])
             ws_rep.append(["Net (Profit)", float(self.bm.net())])
-            ws_rep.append(["Profit Margin", f"{self.bm.profit_margin():.2f}%"]) 
+            ws_rep.append(["Profit Margin", f"{self.bm.profit_margin():.2f}%"])
             for r in range(1, 6):
                 ws_rep[f"A{r}"].font = Font(bold=True)
             ws_rep.column_dimensions['A'].width = 20
@@ -597,8 +597,8 @@ class BudgetApp(tk.Tk):
             ws_rep["B4"].number_format = numbers.FORMAT_CURRENCY_USD_SIMPLE
 
             ws_rep.append([])
-            ws_rep.append(["Expense Breakdown by Category"]) 
-            ws_rep.append(["Category", "Amount", "% of Income", "% of Expenses"]) 
+            ws_rep.append(["Expense Breakdown by Category"])
+            ws_rep.append(["Category", "Amount", "% of Income", "% of Expenses"])
             ws_rep[ws_rep.max_row - 0][0].font = Font(bold=True)
             for cell in ws_rep[ws_rep.max_row]:
                 cell.font = Font(bold=True)
@@ -608,7 +608,7 @@ class BudgetApp(tk.Tk):
             start_row = ws_rep.max_row + 1
             for cat, amt in sorted(by_cat.items()):
                 # Write numeric percentages (0-1) and apply % number format later
-                ws_rep.append([cat, float(amt), (p_inc.get(cat, 0.0) / 100.0), (p_exp.get(cat, 0.0) / 100.0)]) 
+                ws_rep.append([cat, float(amt), (p_inc.get(cat, 0.0) / 100.0), (p_exp.get(cat, 0.0) / 100.0)])
             end_row = ws_rep.max_row
             # Amount formatting for the table
             for row in ws_rep.iter_rows(min_row=start_row, min_col=2, max_col=2):
@@ -627,7 +627,7 @@ class BudgetApp(tk.Tk):
                 rep_table.tableStyleInfo = TableStyleInfo(name="TableStyleMedium9", showRowStripes=True, showColumnStripes=False)
                 ws_rep.add_table(rep_table)
             # Totals row for breakdown
-            ws_rep.append(["Total", f"=SUM(B{start_row}:B{end_row})", "", ""]) 
+            ws_rep.append(["Total", f"=SUM(B{start_row}:B{end_row})", "", ""])
             tot_row_rep = ws_rep.max_row
             ws_rep[f"A{tot_row_rep}"].font = Font(bold=True)
             ws_rep[f"B{tot_row_rep}"].font = Font(bold=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[project]
+name = "monthly-budget-manager"
+version = "1.0.0"
+description = "A cross-platform personal finance tool for tracking monthly income and expenses"
+requires-python = ">=3.10"
+license = "MIT"
+
+[tool.ruff]
+target-version = "py310"
+line-length = 120
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I"]
+
+[tool.ruff.lint.per-file-ignores]
+"budget_manager_gui.py" = ["E501"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[tool.coverage.run]
+source = ["budget_manager"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true

--- a/tests/test_budget_manager.py
+++ b/tests/test_budget_manager.py
@@ -17,8 +17,6 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from budget_manager import (
     BudgetMonth,
-    Expense,
-    Income,
     _clamp_non_negative,
     _is_valid_ym,
     _is_valid_ymd,
@@ -28,7 +26,6 @@ from budget_manager import (
     print_report,
     read_csv,
 )
-
 
 # ===========================================================================
 # Helpers


### PR DESCRIPTION
## Summary

- Remove unused `import math` from `budget_manager.py` (was causing ruff F401 failure)
- Fix import sorting across all Python files to satisfy ruff I001
- Remove unused test imports (`Expense`, `Income`) from test file
- Fix trailing whitespace in `budget_manager_gui.py`
- Wrap long argparse help string to satisfy E501 line-length rule
- **Expand CI ruff lint** to cover `budget_manager_gui.py` and `tests/` (previously only linted `budget_manager.py`)
- **Add root `pyproject.toml`** with unified ruff, pytest, and coverage config
- Add per-file E501 ignore for GUI file (Tkinter layout lines are idiomatic long)

## Audit Results

| Metric | Status |
|--------|--------|
| Tests | 70 passing |
| Coverage | 82% (target: 80%) |
| Lint | Clean (0 errors) |
| CI Matrix | Python 3.10, 3.11, 3.12 |

## Test plan

- [x] `ruff check budget_manager.py budget_manager_gui.py tests/` → 0 errors
- [x] `pytest tests/ --cov=budget_manager --cov-fail-under=80` → 70 passed, 82% coverage
- [ ] CI workflow runs successfully on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)