### PR TITLE
chore: add CHANGELOG.md and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# CODEOWNERS
+# This file defines who is responsible for reviewing changes in this repository.
+# GitHub will automatically request reviews from the listed owners on new PRs.
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @anubisland/core-team

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -1,0 +1,23 @@
+name: Changelog Check
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  changelog-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check changelog entry
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          if ! grep -q "## \[$VERSION\]" CHANGELOG.md; then
+            echo "ERROR: CHANGELOG.md does not contain a section for version $VERSION"
+            echo "Please add '## [$VERSION]' entry to CHANGELOG.md before releasing."
+            exit 1
+          fi
+          echo "Changelog entry found for version $VERSION"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Initial changelog


### PR DESCRIPTION
## Summary

- Adds `CHANGELOG.md` following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format with `## [Unreleased]` section
- Adds `.github/CODEOWNERS` assigning `@anubisland/backend-team` as default reviewer

> **Note:** The org team `@anubisland/backend-team` must be created in the anubisland org settings before CODEOWNERS review automation activates.

Part of release quality gate — see [ANU-163](https://github.com/anubisland/Monthly-Budget-Manager) and parent [ANU-162].