### PR TITLE
ci(release): gate daily release on hygiene workflow (warn) — blocked on ANU-691

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,18 @@ permissions:
   contents: write
 
 jobs:
+  # Release-hygiene gate (ANU-682). Blocks the build when CHANGELOG /
+  # README / docs/guides hygiene rules are not satisfied. Pinned to @v1 of
+  # the reusable workflow published by ANU-691; flip `enforce` to `fail`
+  # after 48 h of clean warn-mode runs (tracked on ANU-722).
+  hygiene:
+    uses: anubisland/.github/.github/workflows/release-hygiene-gate.yml@v1
+    with:
+      enforce: warn
+
   build:
     name: build (${{ matrix.os }})
+    needs: hygiene
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,87 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Each daily release tag (`vYYYYMMDD-HHMM-<sha>`) corresponds to a section below.
+Add a new dated section under `[Unreleased]` whenever user-visible code changes;
+the release-hygiene gate (ANU-682) blocks releases that omit a CHANGELOG entry.
 
 ## [Unreleased]
 
 ### Added
 
-- Initial changelog
+- Release-hygiene gate scaffolding: `docs/` tree with a user guide under
+  `docs/guides/`, and Keep-a-Changelog backfill for recent daily releases.
+
+## [20260430-1040-44d6d77] - 2026-04-30
+
+### Added
+
+- Tag-based and `workflow_dispatch` triggers on `release.yml` so daily release
+  re-runs can be initiated manually or off `v*.*.*` tags.
+
+## [20260430-1038-d96d2ba] - 2026-04-30
+
+### Added
+
+- Scheduled release automation via `release-schedule.yml` (2-day cadence cron).
+
+## [20260430-1016-6bc5eba] - 2026-04-30
+
+### Fixed
+
+- Windows: build shared packages before the Release MSBuild + Metro bundle
+  step so React Native dependencies are present at bundle time.
+
+## [20260430-0520-2a4a049] - 2026-04-30
+
+### Fixed
+
+- Windows: restore the monorepo `metro.config.js` after
+  `react-native-windows-init` clobbers it during scaffolding.
+
+## [20260430-0353-97d3120] - 2026-04-30
+
+### Fixed
+
+- Windows Release: ensure `react-native` is available for the Metro bundler
+  during the packaged build.
+
+## [20260430-0330-d9198d9] - 2026-04-30
+
+### Fixed
+
+- Lint: drop the unused `math` import in `budget_manager.py`.
+
+## [20260430-0322-108edf6] - 2026-04-30
+
+### Fixed
+
+- Android: raise the Gradle heap and limit the CI build to `arm64-v8a` so the
+  release build no longer OOMs on GitHub-hosted runners.
+
+## [20260428-2132-9dc944c] - 2026-04-28
+
+### Fixed
+
+- CI: pin the Windows SDK version and add per-job timeouts so hung jobs no
+  longer block the rest of the matrix.
+
+## [20260425-2053-a271d5e] - 2026-04-25
+
+### Added
+
+- Pytest test suite, Python CI workflow, and an expanded `README.md`.
+
+[Unreleased]: https://github.com/anubisland/Monthly-Budget-Manager/compare/v20260430-1040-44d6d77...HEAD
+[20260430-1040-44d6d77]: https://github.com/anubisland/Monthly-Budget-Manager/releases/tag/v20260430-1040-44d6d77
+[20260430-1038-d96d2ba]: https://github.com/anubisland/Monthly-Budget-Manager/releases/tag/v20260430-1038-d96d2ba
+[20260430-1016-6bc5eba]: https://github.com/anubisland/Monthly-Budget-Manager/releases/tag/v20260430-1016-6bc5eba
+[20260430-0520-2a4a049]: https://github.com/anubisland/Monthly-Budget-Manager/releases/tag/v20260430-0520-2a4a049
+[20260430-0353-97d3120]: https://github.com/anubisland/Monthly-Budget-Manager/releases/tag/v20260430-0353-97d3120
+[20260430-0330-d9198d9]: https://github.com/anubisland/Monthly-Budget-Manager/releases/tag/v20260430-0330-d9198d9
+[20260430-0322-108edf6]: https://github.com/anubisland/Monthly-Budget-Manager/releases/tag/v20260430-0322-108edf6
+[20260428-2132-9dc944c]: https://github.com/anubisland/Monthly-Budget-Manager/releases/tag/v20260428-2132-9dc944c
+[20260425-2053-a271d5e]: https://github.com/anubisland/Monthly-Budget-Manager/releases/tag/v20260425-2053-a271d5e

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,28 @@
+# Monthly Budget Manager — Documentation
+
+This directory hosts the user-facing documentation that ships with each
+release. The release-hygiene gate (ANU-682) requires that `docs/guides/`
+contains at least one guide whenever user-visible code changes.
+
+## Layout
+
+| Path | Contents |
+|------|----------|
+| `docs/guides/` | End-user how-tos: getting started, CLI/GUI usage, exporting data |
+| `docs/README.md` | This index |
+
+## Guides
+
+- [Getting Started](guides/getting-started.md) — install Python, run the CLI
+  and the GUI, and produce a first monthly report.
+- [CLI Reference](guides/cli-reference.md) — every CLI flag with example
+  input and JSON output.
+- [Exporting to Excel](guides/exporting-to-excel.md) — how the GUI export
+  packs charts and tables into an `.xlsx` workbook.
+
+## Project README
+
+The top-level [`README.md`](../README.md) covers feature overview,
+installation, and platform matrix. Anything that documents a workflow longer
+than three paragraphs belongs here under `docs/guides/` instead so the
+release-hygiene gate can audit it.

--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -1,0 +1,98 @@
+# CLI Reference
+
+`budget_manager.py` is a pure-stdlib CLI for tracking monthly income and
+expenses and producing a category breakdown. Run `python3 budget_manager.py
+--help` to print the same flag list locally.
+
+## Usage
+
+```text
+budget_manager.py [-h] [--input INPUT] [--month MONTH] [--json]
+                  [--save-json SAVE_JSON]
+```
+
+## Flags
+
+| Flag | Argument | Default | Behaviour |
+|------|----------|---------|-----------|
+| `--input` | path to CSV | (interactive) | Import incomes and expenses from a `type,name,category,amount` CSV instead of prompting. |
+| `--month` | label, e.g. `2026-05` | current month | Title used for the report header and JSON `month` field. |
+| `--json`  | (flag) | off | Emit the report as JSON to stdout instead of a human-readable table. |
+| `--save-json` | path | (none) | Also write the JSON report to the given path. Combine with or without `--json`. |
+| `-h`, `--help` | — | — | Print usage and exit. |
+
+## CSV input format
+
+`--input` reads a header-less or header-delimited CSV with four columns:
+
+```csv
+type,name,category,amount
+income,Salary,work,4500
+expense,Rent,housing,1500
+expense,Groceries,food,420
+```
+
+- `type` must be `income` or `expense` (case-insensitive).
+- `category` is free-form; the report groups expenses by this column.
+- `amount` is parsed as a float; negative values are treated as zero.
+
+## Examples
+
+### Interactive run
+
+```bash
+python3 budget_manager.py --month 2026-05
+```
+
+Enter line items when prompted; leave the name blank to finish a section.
+
+### CSV → table
+
+```bash
+python3 budget_manager.py --input examples/sample_budget.csv --month 2026-05
+```
+
+### CSV → JSON for a pipeline
+
+```bash
+python3 budget_manager.py \
+  --input examples/sample_budget.csv \
+  --month 2026-05 \
+  --json | jq '.summary'
+```
+
+### CSV → JSON file (and console table)
+
+```bash
+python3 budget_manager.py \
+  --input examples/sample_budget.csv \
+  --save-json reports/2026-05.json
+```
+
+## JSON output schema
+
+```jsonc
+{
+  "month": "2026-05",
+  "summary": {
+    "income_total": 4500.0,
+    "expense_total": 1920.0,
+    "profit": 2580.0,
+    "profit_margin": 0.5733
+  },
+  "incomes": [{"name": "Salary", "category": "work", "amount": 4500.0}],
+  "expenses": [{"name": "Rent", "category": "housing", "amount": 1500.0}],
+  "by_category": [
+    {"category": "housing", "amount": 1500.0, "pct_of_expense": 0.78,
+     "pct_of_income": 0.33}
+  ]
+}
+```
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Report produced successfully |
+| 2 | Invalid CLI usage (argparse error) |
+| 1 | Unhandled exception (e.g. unreadable CSV) |

--- a/docs/guides/exporting-to-excel.md
+++ b/docs/guides/exporting-to-excel.md
@@ -1,0 +1,74 @@
+# Exporting to Excel
+
+The desktop GUI (`budget_manager_gui.py`) can save the current month's
+report as an `.xlsx` workbook with formatted tables and embedded charts.
+This guide explains what the export contains and how to script it.
+
+## Prerequisite
+
+Excel export uses [`openpyxl`](https://pypi.org/project/openpyxl/), which is
+installed automatically by `pip install -r requirements.txt`.
+
+## Triggering the export
+
+1. Launch the GUI:
+   ```bash
+   python3 budget_manager_gui.py
+   ```
+2. Enter incomes and expenses, or use **File → Open** to load a saved
+   budget.
+3. Choose **File → Export to Excel** (or press `Ctrl+E`).
+4. Pick a destination path. The default name is
+   `Monthly-Budget-<YYYY-MM>.xlsx`.
+
+## What the workbook contains
+
+| Sheet | Contents |
+|-------|----------|
+| **Summary** | Headline KPIs: total income, total expense, profit, profit margin. |
+| **Incomes** | One row per income line item (name, category, amount). |
+| **Expenses** | One row per expense line item (name, category, amount). |
+| **Categories** | Per-category amount, % of income, % of expenses. |
+| **Charts** | Embedded bar chart (income vs expenses) and pie chart (expense categories). |
+
+Header rows are styled bold; numeric columns are formatted as currency with
+two decimal places.
+
+## Re-importing an exported workbook
+
+The GUI does **not** read `.xlsx` directly — re-importing means converting
+back to CSV. The simplest path is:
+
+```bash
+python3 -c "
+from openpyxl import load_workbook
+import csv, sys
+wb = load_workbook(sys.argv[1])
+with open(sys.argv[2], 'w', newline='') as out:
+    w = csv.writer(out)
+    w.writerow(['type','name','category','amount'])
+    for sheet, kind in (('Incomes','income'), ('Expenses','expense')):
+        ws = wb[sheet]
+        for row in ws.iter_rows(min_row=2, values_only=True):
+            name, category, amount = row[:3]
+            if name is None: continue
+            w.writerow([kind, name, category, amount])
+" report.xlsx report.csv
+```
+
+Then pipe the CSV back into the CLI:
+
+```bash
+python3 budget_manager.py --input report.csv --json
+```
+
+## Troubleshooting
+
+- **Charts missing on re-open** — Excel < 2016 cannot render the embedded
+  `openpyxl` chart objects; use a current Excel, LibreOffice Calc, or
+  Numbers.
+- **Currency formatting wrong** — `openpyxl` uses the workbook's default
+  locale. Open the workbook in your spreadsheet app and adjust the
+  **Categories** sheet's number format.
+- **`PermissionError` on save** — close any spreadsheet app that has the
+  target file open before retrying the export.

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -1,0 +1,78 @@
+# Getting Started
+
+This guide walks through running Monthly Budget Manager from a fresh
+checkout: install Python, set up dependencies, run the CLI, and launch the
+desktop GUI.
+
+## 1. Install Python
+
+Monthly Budget Manager targets **Python 3.10 or newer**. Confirm your
+interpreter:
+
+```bash
+python3 --version
+```
+
+If `python3` is missing, install the latest 3.x release from
+[python.org](https://www.python.org/downloads/) or your platform's package
+manager (`brew install python`, `apt install python3`, etc.).
+
+## 2. Get the source
+
+```bash
+git clone https://github.com/anubisland/Monthly-Budget-Manager.git
+cd Monthly-Budget-Manager
+```
+
+## 3. Install dependencies
+
+Only the GUI needs third-party packages (`openpyxl` for Excel export and
+`tkcalendar` for the date picker). The CLI runs on the standard library
+alone.
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate        # Windows: .venv\Scripts\activate
+pip install -r requirements.txt
+```
+
+## 4. Run the CLI
+
+```bash
+python3 budget_manager.py
+```
+
+You will be prompted for incomes and expenses. Leave the name blank to end
+each section. The CLI prints a summary table and a category breakdown.
+
+For non-interactive use, point the CLI at a CSV (`type,name,category,amount`):
+
+```bash
+python3 budget_manager.py --input examples/sample_budget.csv --json
+```
+
+See the [CLI Reference](cli-reference.md) for every flag.
+
+## 5. Launch the desktop GUI
+
+```bash
+python3 budget_manager_gui.py
+```
+
+Useful keyboard shortcuts:
+
+| Shortcut | Action |
+|----------|--------|
+| `Ctrl+O` | Open a saved budget file |
+| `Ctrl+S` | Save the current budget |
+| `F5`     | Refresh the report and charts |
+
+To export the current view to Excel, use **File → Export to Excel** or see
+[Exporting to Excel](exporting-to-excel.md).
+
+## 6. Next steps
+
+- Browse [`examples/`](../../examples) for sample CSV inputs.
+- Read the [CLI Reference](cli-reference.md) before scripting Budget Manager
+  into a pipeline.
+- Track release notes in [`CHANGELOG.md`](../../CHANGELOG.md).


### PR DESCRIPTION
## Summary

> **DRAFT — do not merge until [ANU-691](https://paperclip.elwazir.org/ANU/issues/ANU-691) publishes `anubisland/.github/.github/workflows/release-hygiene-gate.yml@v1`.** The `uses:` reference will 404 until then and break every daily release.

Wires the [release-hygiene gate (ANU-682)](https://paperclip.elwazir.org/ANU/issues/ANU-682) into `.github/workflows/release.yml`:

- New top-level `hygiene` job that calls the reusable workflow at `anubisland/.github/.github/workflows/release-hygiene-gate.yml@v1` with `enforce: warn`.
- `build` matrix now `needs: hygiene`, so every daily release picks up the CHANGELOG / README / docs/guides audit.
- Companion docs/CHANGELOG backfill is in #11 and is safe to merge first.

## Pilot plan (per [ANU-722](https://paperclip.elwazir.org/ANU/issues/ANU-722))

1. Land in `warn` mode — misses surface as workflow notices but daily release still ships.
2. After **48 h of clean warn-mode runs**, open a follow-up PR flipping `enforce: warn` → `enforce: fail`.
3. Block the project's first `fail`-mode daily release on ANU-722 being marked done.
4. Comment back on ANU-682 with a green release run when `fail` mode is live.

## Test plan

- [ ] ANU-691 has tagged `anubisland/.github` `v1` and the reusable workflow exists at the pinned ref.
- [ ] Open this PR off draft; CI must show the `hygiene` job runs and produces warn-mode output.
- [ ] Tag a manual `v*.*.*` release and confirm `release.yml` triggers `hygiene → build → release → mobile → release-mobile → notify` in that dependency order.
- [ ] Push a test commit that touches user-visible code without a CHANGELOG bump and confirm the gate emits a warning (not a failure) in warn mode.

## Acceptance after flip-to-fail

- A test commit that touches user-visible code without a CHANGELOG bump fails the gate (red CI run linked in the closing comment on ANU-722).
- README link / fenced code-block smoke is green.