### PR TITLE
ci(rn): replace retired macos-13 runner with macos-14; add iOS 26 SDK preflight

### DIFF
--- a/.github/workflows/react-native-build.yml
+++ b/.github/workflows/react-native-build.yml
@@ -116,7 +116,7 @@ jobs:
 
   ios:
     name: iOS Archive
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 60
     defaults:
       run:
@@ -153,6 +153,33 @@ jobs:
           else
             echo "iOS project not initialized; skipping"
           fi
+      - name: iOS 26 SDK preflight (fail-fast)
+        # Required by ANU-769 audit: App Store submission needs Xcode 26+ with iphoneos26.* SDK.
+        # Hard-fails if the runner image is older so the gap is visible instead of silently soft-passing.
+        run: |
+          set -euo pipefail
+          echo "::group::xcodebuild -version"
+          xcodebuild -version
+          echo "::endgroup::"
+          echo "::group::xcodebuild -showsdks"
+          xcodebuild -showsdks
+          echo "::endgroup::"
+
+          XCODE_MAJOR=$(xcodebuild -version | awk '/^Xcode/ { split($2, v, "."); print v[1]; exit }')
+          if [ -z "${XCODE_MAJOR:-}" ]; then
+            echo "::error::Could not parse Xcode version from xcodebuild -version output"
+            exit 1
+          fi
+          if [ "$XCODE_MAJOR" -lt 26 ]; then
+            echo "::error::Xcode ${XCODE_MAJOR} detected; App Store submission requires Xcode 26+. Upgrade the runner image (current: ${ImageOS:-unknown})."
+            exit 1
+          fi
+          if ! xcodebuild -showsdks | grep -qE '^[[:space:]]*iOS[[:space:]]+26\.|iphoneos26\.'; then
+            echo "::error::iphoneos26.* SDK not present on this runner. App Store submission requires the iOS 26 SDK."
+            exit 1
+          fi
+
+          echo "Preflight OK: Xcode ${XCODE_MAJOR} with iphoneos26 SDK present."
       - name: Build iOS (Release device archive)
         run: |
           if [ -d ios ]; then
@@ -310,7 +337,7 @@ jobs:
 
   macos:
     name: macOS App
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 60
     defaults:
       run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Added
 
 - Initial changelog
+- iOS workflow preflight that fails fast when the runner lacks Xcode 26+ / `iphoneos26.*` SDK, surfacing App Store submission gaps in CI (ANU-532, ANU-769).
+
+### Changed
+
+- React Native CI: replace retired `macos-13` (Ventura) runner label with `macos-14` for both `ios` and `macos` jobs to stop 24h queue timeouts (ANU-532, ANU-506).


### PR DESCRIPTION
## Summary

- Replace `runs-on: macos-13` with `macos-14` in `.github/workflows/react-native-build.yml` for both the `ios` and `macos` jobs. GitHub retired the `macos-13` (Ventura) hosted-runner image, so every iOS/macOS job in this workflow has been sitting `queued` for 24h and auto-cancelling since 2026-04-28 (see investigation in ANU-506). Pinning to `macos-14` keeps CI reproducible vs. `macos-latest` floating.
- Add a fail-fast **iOS 26 SDK preflight** step before `Build iOS (Release device archive)`. It prints `xcodebuild -version` and `xcodebuild -showsdks` and hard-fails if Xcode major version `< 26` or the `iphoneos26.*` SDK is not present. Required by the ANU-769 audit so the App Store submission-readiness gap is visible in CI instead of being masked by the existing `|| true` on the build step.
- CHANGELOG entries under `[Unreleased]`.

## Why

Tracking ticket: **ANU-532** (parent investigation: ANU-506; iOS 26 readiness audit: ANU-769). The discovery gate (ANU-65) that previously parked this issue is now lifted — ANU-48 is done.

## Why `macos-14` and not `macos-latest`

Pinning a specific image keeps CI reproducible and avoids surprise re-floats of `macos-latest` (which currently points to `macos-15`). `macos-14` is the current conservative replacement for the retired `macos-13`. If the iOS 26 preflight surfaces the need for a newer image (it likely will), bumping to `macos-15` / `macos-26` is a one-line follow-up — and that's exactly what the preflight is designed to surface.

## Expected CI behavior on this PR

- `android` / `windows`: unchanged.
- `ios` / `macos`: jobs will now schedule onto `macos-14` runners (no more 24h queue timeout).
- `ios` archive step: the new preflight will likely **fail** on `macos-14` because that image ships with Xcode 15.x, not Xcode 26+. **That failure is the intended signal** — it documents the iOS 26 SDK gap from the ANU-769 audit. Follow-up work to bump to a runner with Xcode 26 will be tracked separately.

## Test plan

- [ ] CI run completes on this PR (no 24h iOS/macOS queue timeout).
- [ ] iOS preflight step prints Xcode version + SDK list in the job log.
- [ ] Either the preflight fails fast with the documented `::error::` message (expected on `macos-14`), or it passes and the archive step runs.
- [ ] After merge: comment back on ANU-506 with the green-or-explicitly-failed run URL.

Refs: ANU-532, ANU-506, ANU-769.

🤖 Generated with [Claude Code](https://claude.com/claude-code)